### PR TITLE
Add language detection tests

### DIFF
--- a/letterngram/letterngram.py
+++ b/letterngram/letterngram.py
@@ -41,18 +41,22 @@ def letterngrams(text, num=1, charset='alpha'):
     ngramsdict = {}
     idx = 0
     tot = 0
-    for i in range(1, len(text)-num):
+    for i in range(1, len(text) - num):
+        ngram = None
+        chunk = text[idx + i:idx + i + num]
         if charset == 'alpha':
-            if text[idx + i:idx + i + num].isalpha():
-                ngram = text[idx + i:idx + i + num]
+            if chunk.isalpha():
+                ngram = chunk
         elif charset == 'alphanum':
-            if text[idx + i:idx + i + num].isalnum():
-                ngram = text[idx + i:idx + i + num]
+            if chunk.isalnum():
+                ngram = chunk
         elif charset == 'num':
-            if text[idx + i:idx + i + num].isdigit():
-                ngram = text[idx + i:idx + i + num]
+            if chunk.isdigit():
+                ngram = chunk
         elif charset == 'all':
-            ngram = text[idx + i:idx + i + num]
+            ngram = chunk
+        if ngram is None:
+            continue
         if ngram in ngramsdict:
             ngramsdict[ngram] += 1
             tot += 1

--- a/tests/test_lang_detect.py
+++ b/tests/test_lang_detect.py
@@ -1,0 +1,48 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+import unittest
+from unittest import mock
+
+import OHNLP.letterngram.letterngram as ln
+from OHNLP.langdetector.langdetector import language_detection
+
+LANGUAGE_SAMPLES = [
+    ("english", "hello"),
+    ("mandarin", "ni hao"),
+    ("hindi", "namaste mere dost"),
+    ("spanish", "hola mi buen amigo"),
+    ("arabic", "marhaban kayfa halak ya sadiqi"),
+    ("bengali", "halo amar priyo bandhu kamon acho"),
+    ("french", "bonjour mon cher ami comment allez vous"),
+    ("russian", "privet moy dorogoy drug kak ty segodnya"),
+    ("portuguese", "ola meu querido amigo como voce esta hoje"),
+    ("urdu", "salam mere pyare dost aap kaise hain aaj sab theek"),
+]
+
+
+def _make_models():
+    models = {}
+    for lang, sample in LANGUAGE_SAMPLES:
+        models[lang] = ln.letterngrams(sample, num=2, charset="alpha")
+    return models
+
+
+class TestLanguageDetection(unittest.TestCase):
+    def setUp(self):
+        self.patcher = mock.patch(
+            "OHNLP.langdetector.langdetector.readmodels",
+            return_value=_make_models(),
+        )
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_detection(self):
+        for lang, sample in LANGUAGE_SAMPLES:
+            with self.subTest(language=lang):
+                self.assertEqual(language_detection(sample), lang)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle non-alphabetic chunks in `letterngrams`
- add unit tests covering language detection for 10 languages

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae3a0365c832c939061c56d7e0194