### PR TITLE
Refactor sentence splitter and add tests

### DIFF
--- a/splitter/splitter.py
+++ b/splitter/splitter.py
@@ -5,37 +5,27 @@ sentences
 """
 import re
 
-INITIALS_RE = re.compile(r'([A-z])\.')
+INITIALS_RE = re.compile(r"\b([A-Za-z])\.")
+ABBREV_RE = re.compile(
+    r"\b(?:Ph\.D|Mr|St|Mrs|Ms|Dr|Drs|vs|etc|Inc|Ltd|Jr|Sr|Co)\.(?=\s+[A-Z])"
+)
+
 
 def splitter(text):
     """
     Basic sentence splitting routine
     It doesn't take into account dialog or quoted sentences inside a sentence.
     """
-    sentences = []
-    # First step remove newlines
-    text = text.replace('\n', ' ')
-    # we remove tabs
-    text = text.replace('\t', ' ')
-    # then we replace abbreviations
-    text = text.replace('Ph.D.', "Ph<prd>D<prd>")
-    text = text.replace('Mr.', 'Mr<prd>')
-    text = text.replace('St.', 'Mr<prd>')
-    text = text.replace('Mrs.', 'Mrs<prd>')
-    text = text.replace('Ms.', 'Ms<prd>')
-    text = text.replace('Dr.', 'Dr<prd>')
-    text = text.replace('Drs.', 'Drs<prd>')
-    text = text.replace('vs.', 'vs<prd>')
-    text = text.replace('etc.', 'etc<prd>')
-    text = text.replace('Inc.', 'Inc<prd>')
-    text = text.replace('Ltd.', 'Ltd<prd>')
-    text = text.replace('Jr.', 'Jr<prd>')
-    text = text.replace('Sr.', 'Sr<prd>')
-    text = text.replace('Co.', 'Co<prd>')
-    text = INITIALS_RE.sub('\1<prd>', text)
-    text = text.replace('.', '.<stop>')
-    text = text.replace('?', '?<stop>')
-    text = text.replace('!', '!<stop>')
-    text = text.replace('<prd>', '.')
-    sentences = text.split('<stop>')
+    # Normalize whitespace
+    text = text.replace("\n", " ").replace("\t", " ")
+
+    # Protect abbreviations and initials
+    text = ABBREV_RE.sub(lambda m: m.group(0).replace(".", "<prd>"), text)
+    text = INITIALS_RE.sub(r"\1<prd>", text)
+
+    # Split sentences on punctuation followed by whitespace
+    parts = re.split(r"(?<=[.!?])\s+", text)
+
+    # Restore protected periods
+    sentences = [p.replace("<prd>", ".") for p in parts if p]
     return sentences

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)  # noqa: E402
+
+from OHNLP.splitter.splitter import splitter  # noqa: E402
+
+
+class TestSplitter(unittest.TestCase):
+    def test_abbreviations(self):
+        text = (
+            "Mr. John met Mrs. Jane at St. Patrick's Cathedral. "
+            "They talked with Dr. Smith."
+        )
+        expected = [
+            "Mr. John met Mrs. Jane at St. Patrick's Cathedral.",
+            "They talked with Dr. Smith.",
+        ]
+        self.assertEqual(splitter(text), expected)
+
+    def test_multiline(self):
+        text = "Hello world!\nHow are you today? I am fine."
+        expected = ["Hello world!", "How are you today?", "I am fine."]
+        self.assertEqual(splitter(text), expected)
+
+    def test_complex(self):
+        text = "Dr. Strange loves the U.S.A. He said hi."
+        expected = ["Dr. Strange loves the U.S.A. He said hi."]
+        self.assertEqual(splitter(text), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- optimize sentence splitter by using regex for abbreviation handling
- add test suite for sentence splitting covering abbreviations and multi-line input

## Testing
- `flake8 splitter/splitter.py tests/test_splitter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae62cfb9c832c8f3414cfb54fd80f