### PR TITLE
Add wordsngram module with tests

### DIFF
--- a/tests/test_wordsngram.py
+++ b/tests/test_wordsngram.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+)  # noqa: E402
+
+from OHNLP.wordsngram.wordsngram import wordsngram  # noqa: E402
+
+
+class TestWordsNgram(unittest.TestCase):
+    def test_unigram_single_word(self):
+        result = wordsngram("Hi.", n=1, mode="front")
+        expected = {("Hi",): 0.5, (".",): 0.5}
+        self.assertEqual(result, expected)
+
+    def test_bigram_front_abbrev(self):
+        text = "Hello, U.S.A. world."
+        result = wordsngram(text, n=2, mode="front")
+        expected = [
+            ("Hello", ","),
+            (",", "U.S.A."),
+            ("U.S.A.", "world"),
+            ("world", "."),
+        ]
+        self.assertEqual(set(result.keys()), set(expected))
+        for freq in result.values():
+            self.assertAlmostEqual(freq, 1 / 4)
+
+    def test_bigram_back_abbrev(self):
+        text = "Hello, U.S.A. world."
+        result = wordsngram(text, n=2, mode="back")
+        expected = [
+            (".", "world"),
+            ("world", "U.S.A."),
+            ("U.S.A.", ","),
+            (",", "Hello"),
+        ]
+        self.assertEqual(set(result.keys()), set(expected))
+
+    def test_trigram_window(self):
+        result = wordsngram("Hi there", n=3, mode="window")
+        expected = [
+            ("<s>", "<s>", "Hi"),
+            ("<s>", "Hi", "there"),
+            ("Hi", "there", "</s>"),
+            ("there", "</s>", "</s>"),
+        ]
+        self.assertEqual(set(result.keys()), set(expected))
+        for freq in result.values():
+            self.assertAlmostEqual(freq, 1 / 4)
+
+    def test_long_phrase(self):
+        words = [f"w{i}" for i in range(1, 21)]
+        text = " ".join(words[:2]) + ", " + " ".join(words[2:]) + "."
+        result = wordsngram(text, n=1, mode="front")
+        expected_tokens = [(w,) for w in words + [",", "."]]
+        self.assertEqual(set(result.keys()), set(expected_tokens))
+        for freq in result.values():
+            self.assertAlmostEqual(freq, 1 / 22)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wordsngram/wordsngram.py
+++ b/wordsngram/wordsngram.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Word n-gram calculator for text.
+
+Generates a normalized frequency distribution of word n-grams. Punctuation
+marks are treated as tokens unless they are part of an abbreviation.
+"""
+
+import re
+from collections import Counter
+
+# Pattern matching common abbreviations and sequences like "U.S.A."
+TOKEN_RE = re.compile(
+    r"(?:[A-Za-z]\.){2,}[A-Za-z]?\.?|"
+    r"(?:Mr|St|Mrs|Ms|Dr|Drs|vs|etc|Inc|Ltd|Jr|Sr|Co|Ph\.D)\.|"
+    r"\w+(?:'\w+)?|[^\w\s]"
+)
+
+
+def _tokenize(text: str):
+    """Return a list of tokens from *text* considering abbreviations."""
+    text = text.replace("\n", " ").replace("\t", " ")
+    return TOKEN_RE.findall(text)
+
+
+def wordsngram(text: str, n: int = 1, mode: str = "front"):
+    """Return ``n``-gram frequencies for *text*.
+
+    ``mode`` selects how n-grams are created: ``front`` from start to end,
+    ``back`` from end to start, and ``window`` pads the text with ``<s>`` and
+    ``</s>`` symbols.
+    """
+
+    tokens = _tokenize(text)
+    if not tokens or n <= 0:
+        return {}
+
+    if mode not in {"front", "back", "window"}:
+        raise ValueError("mode must be 'front', 'back' or 'window'")
+
+    if mode == "back":
+        tokens = list(reversed(tokens))
+    elif mode == "window":
+        tokens = ["<s>"] * (n - 1) + tokens + ["</s>"] * (n - 1)
+
+    ngrams = [tuple(tokens[i:i + n]) for i in range(len(tokens) - n + 1)]
+    total = len(ngrams)
+    freq = Counter(ngrams)
+    return {k: v / total for k, v in freq.items()}


### PR DESCRIPTION
## Summary
- implement `wordsngram` to produce word n-grams with punctuation handling and three modes
- add comprehensive tests for different modes and input lengths

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b85d72bc8832c8a69c609b95ac980